### PR TITLE
Add Customer Proguard Rules

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+# 1.12.1 - Mon 15 Jul 2020
+
+- Add customer proguard rules
+
 # 1.12.0 - Mon 06 Jul 2020
 
 - Add mute and unmute methods to channel controller

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
-        versionName "1.12.0"
+        versionName "1.12.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,9 +21,11 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'consumer-proguard-rules.pro'
         }
         debug {
             testCoverageEnabled true
+            consumerProguardFiles 'consumer-proguard-rules.pro'
         }
     }
     compileOptions {

--- a/library/consumer-proguard-rules.pro
+++ b/library/consumer-proguard-rules.pro
@@ -1,0 +1,13 @@
+## Stream Chat Android Client Proguard Rules
+
+-keep class io.getstream.chat.android.client.api.* { *; }
+-keep class io.getstream.chat.android.client.api.models.* { *; }
+-keep class io.getstream.chat.android.client.errors.* { *; }
+-keep class io.getstream.chat.android.client.events.* { *; }
+-keep class io.getstream.chat.android.client.models.* { *; }
+-keep class io.getstream.chat.android.client.socket.* { *; }
+-keep class io.getstream.chat.android.client.utils.SyncStatus { *; }
+
+-keepattributes Signature,*Annotation*
+
+-keepattributes EnclosingMethod


### PR DESCRIPTION
Adding this proguard configuration, consumers doesn't need to add any extra rule on their proguard file to be compatible with our SDK