### PR TITLE
Refactor Flag methods

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,14 @@
+# 1.13.0 - Tue 28 Jul 2020
+
+- Add `Client.flagUser()` method to flag an User
+- Add `Client.flagMessage()` method to flag a Message
+- Deprecated method `Client.flag()` because was a bit confusing, you should use `client.flagUser()` instead
+
 # 1.12.3 - Mon 27 Jul 2020
 
 - Fix NPE on TokenManagerImpl
 - Upgrade Kotlin to version 1.3.72
-- Add Kotlin Proguard Rules 
+- Add Kotlin Proguard Rules
 
 # 1.12.2 - Fri 17 Jul 2020
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,7 +15,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
-        versionName "1.12.3"
+        versionName "1.13.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/library/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -163,6 +163,8 @@ interface ChatClient {
     fun unmuteUser(userId: String): Call<Mute>
     fun unmuteCurrentUser(): Call<Mute>
     fun flag(targetId: String): Call<Flag>
+    fun flagUser(userId: String): Call<Flag>
+    fun flagMessage(messageId: String): Call<Flag>
     fun banUser(
         targetId: String,
         channelType: String,

--- a/library/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -162,7 +162,12 @@ interface ChatClient {
     fun muteCurrentUser(): Call<Mute>
     fun unmuteUser(userId: String): Call<Mute>
     fun unmuteCurrentUser(): Call<Mute>
-    fun flag(targetId: String): Call<Flag>
+
+    @Deprecated(
+        message = "We are going to replace with flagUser()",
+        replaceWith = ReplaceWith("this.flagUser(userId)")
+    )
+    fun flag(userId: String): Call<Flag>
     fun flagUser(userId: String): Call<Flag>
     fun flagMessage(messageId: String): Call<Flag>
     fun banUser(

--- a/library/src/main/java/io/getstream/chat/android/client/ChatClientImpl.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/ChatClientImpl.kt
@@ -429,7 +429,11 @@ internal class ChatClientImpl(
 
     override fun muteCurrentUser(): Call<Mute> = api.muteCurrentUser()
 
-    override fun flag(targetId: String) = api.flag(targetId)
+    override fun flag(targetId: String) = flagUser(targetId)
+
+    override fun flagUser(userId: String) = api.flagUser(userId)
+
+    override fun flagMessage(messageId: String) = api.flagMessage(messageId)
 
     override fun translate(messageId: String, language: String) = api.translate(messageId, language)
 

--- a/library/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -157,7 +157,11 @@ interface ChatApi {
 
     fun unmuteCurrentUser(): Call<Mute>
 
-    fun flag(targetId: String): Call<Flag>
+    @Deprecated(
+        message = "We are going to replace with flagUser()",
+        replaceWith = ReplaceWith("this.flagUser(userId)")
+    )
+    fun flag(userId: String): Call<Flag>
 
     fun flagUser(userId: String): Call<Flag>
 

--- a/library/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -157,9 +157,11 @@ interface ChatApi {
 
     fun unmuteCurrentUser(): Call<Mute>
 
-    fun flag(
-        targetId: String
-    ): Call<Flag>
+    fun flag(targetId: String): Call<Flag>
+
+    fun flagUser(userId: String): Call<Flag>
+
+    fun flagMessage(messageId: String): Call<Flag>
 
     fun banUser(
         targetId: String,

--- a/library/src/main/java/io/getstream/chat/android/client/api/ChatApiImpl.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/api/ChatApiImpl.kt
@@ -678,14 +678,12 @@ internal class ChatApiImpl(
         ).map { it.mute }
     }
 
-    override fun flag(
-        targetId: String
-    ): Call<Flag> {
+    override fun flag(targetId: String): Call<Flag> = flagUser(targetId)
+    override fun flagUser(userId: String): Call<Flag> = flag(mutableMapOf("target_user_id" to userId))
+    override fun flagMessage(messageId: String): Call<Flag> = flag(mutableMapOf("target_message_id" to messageId))
 
-        val body: MutableMap<String, String> = HashMap()
-        body["target_user_id"] = targetId
-
-        return callMapper.map(
+    private fun flag(body: MutableMap<String, String>): Call<Flag> =
+        callMapper.map(
             retrofitApi.flag(
                 apiKey,
                 userId,
@@ -693,7 +691,6 @@ internal class ChatApiImpl(
                 body
             )
         ).map { it.flag }
-    }
 
     override fun banUser(
         targetId: String,

--- a/library/src/main/java/io/getstream/chat/android/client/models/Flag.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/models/Flag.kt
@@ -6,7 +6,7 @@ import java.util.Date
 data class Flag(
     val user: User,
     @SerializedName("target_user")
-    val targetUser: User,
+    val targetUser: User?,
     @SerializedName("target_message_id")
     val targetMessageId: String,
     @SerializedName("created_at")

--- a/library/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
+++ b/library/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
@@ -119,6 +119,69 @@ class UsersApiCallsTests {
     }
 
     @Test
+    fun flagUserSuccess() {
+
+        val targetUserId = "target-id"
+        val user = User("user-id")
+        val targetUser = User(targetUserId)
+        val date = Date()
+        val flag = Flag(
+            user,
+            targetUser,
+            "",
+            "",
+            false,
+            date,
+            date,
+            date,
+            date,
+            date
+        )
+
+        Mockito.`when`(
+            mock.retrofitApi.flag(
+                mock.apiKey, mock.userId, mock.connectionId,
+                mapOf(Pair("target_user_id", targetUserId))
+            )
+        ).thenReturn(RetroSuccess(FlagResponse(flag)))
+
+        val result = client.flagUser(targetUserId).execute()
+
+        verifySuccess(result, flag)
+    }
+
+    @Test
+    fun flagMessageSuccess() {
+
+        val targetMessageId = "message-id"
+        val user = User("user-id")
+        val date = Date()
+        val flag = Flag(
+            user,
+            null,
+            targetMessageId,
+            "",
+            false,
+            date,
+            date,
+            date,
+            date,
+            date
+        )
+
+        Mockito.`when`(
+            mock.retrofitApi.flag(
+                mock.apiKey, mock.userId, mock.connectionId,
+                mapOf(Pair("target_message_id", targetMessageId))
+            )
+        ).thenReturn(RetroSuccess(FlagResponse(flag)))
+
+        val result = client.flagMessage(targetMessageId).execute()
+
+        verifySuccess(result, flag)
+    }
+
+    @Test
     fun getUsersSuccess() {
 
         val user = User().apply { id = "a-user" }

--- a/sample/src/main/java/io/getstream/chat/android/client/sample/common/TestUsersApiMethodsActivity.kt
+++ b/sample/src/main/java/io/getstream/chat/android/client/sample/common/TestUsersApiMethodsActivity.kt
@@ -12,7 +12,20 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.sample.App
 import io.getstream.chat.android.client.sample.R
 import io.getstream.chat.android.client.utils.FilterObject
-import kotlinx.android.synthetic.main.activity_test_user_api.*
+import kotlinx.android.synthetic.main.activity_test_user_api.testUserApiAddMembersBtn
+import kotlinx.android.synthetic.main.activity_test_user_api.testUserApiAnonymousBtn
+import kotlinx.android.synthetic.main.activity_test_user_api.testUserApiBanUserBtn
+import kotlinx.android.synthetic.main.activity_test_user_api.testUserApiFlagUserBtn
+import kotlinx.android.synthetic.main.activity_test_user_api.testUserApiFunctionalityGroup
+import kotlinx.android.synthetic.main.activity_test_user_api.testUserApiGuestBtn
+import kotlinx.android.synthetic.main.activity_test_user_api.testUserApiLoadingShapeContainer
+import kotlinx.android.synthetic.main.activity_test_user_api.testUserApiLoginGroup
+import kotlinx.android.synthetic.main.activity_test_user_api.testUserApiMuteUserBtn
+import kotlinx.android.synthetic.main.activity_test_user_api.testUserApiQueryUsersBtn
+import kotlinx.android.synthetic.main.activity_test_user_api.testUserApiRemoveMembersBtn
+import kotlinx.android.synthetic.main.activity_test_user_api.testUserApiSetRegularUserBtn
+import kotlinx.android.synthetic.main.activity_test_user_api.testUserApiUnBanUserBtn
+import kotlinx.android.synthetic.main.activity_test_user_api.testUserApiUnMuteUserBtn
 
 class TestUsersApiMethodsActivity : AppCompatActivity() {
 
@@ -168,8 +181,8 @@ class TestUsersApiMethodsActivity : AppCompatActivity() {
     }
 
     private fun flag() {
-        client.flag(
-            targetId = "stream-eugene"
+        client.flagUser(
+            userId = "stream-eugene"
         ).enqueue { result ->
             // echoResult(result, "Flag successful")
         }

--- a/sample/src/main/java/io/getstream/chat/android/client/sample/common/TestUsersApiMethodsActivity.kt
+++ b/sample/src/main/java/io/getstream/chat/android/client/sample/common/TestUsersApiMethodsActivity.kt
@@ -181,9 +181,7 @@ class TestUsersApiMethodsActivity : AppCompatActivity() {
     }
 
     private fun flag() {
-        client.flagUser(
-            userId = "stream-eugene"
-        ).enqueue { result ->
+        client.flagUser("stream-eugene").enqueue { result ->
             // echoResult(result, "Flag successful")
         }
     }


### PR DESCRIPTION
-. Add a new method to flag a message.
-. Add a new method to flag an User

`Client.flag()` implementation was a bit confusing, it takes as a parameter an string called `targetId` that didn't represent the real behavior it has (Flag an User). It has been marked as deprecated and indicated which method should be used instead