### PR TITLE
Hotfix date parser

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+# 1.13.1 - Fri 7 Aug 2020
+
+- Fix DateParser
+
 # 1.13.0 - Tue 28 Jul 2020
 
 - Add `Client.flagUser()` method to flag an User

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,7 +15,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
-        versionName "1.13.0"
+        versionName "1.13.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/library/src/main/java/io/getstream/chat/android/client/parser/ChatParser.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/parser/ChatParser.kt
@@ -7,10 +7,6 @@ import retrofit2.Retrofit
 
 interface ChatParser {
 
-    companion object {
-        const val DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-    }
-
     fun toJson(any: Any): String
     fun <T> fromJson(raw: String, clazz: Class<T>): T
     fun <T> fromJsonOrError(raw: String, clazz: Class<T>): Result<T>

--- a/library/src/main/java/io/getstream/chat/android/client/parser/ChatParserImpl.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/parser/ChatParserImpl.kt
@@ -21,7 +21,6 @@ class ChatParserImpl : ChatParser {
     val gson: Gson by lazy {
         GsonBuilder()
             .registerTypeAdapterFactory(TypeAdapterFactory())
-            .setDateFormat(ChatParser.DATE_FORMAT)
             .addSerializationExclusionStrategy(object : ExclusionStrategy {
                 override fun shouldSkipClass(clazz: Class<*>): Boolean {
                     return false

--- a/library/src/main/java/io/getstream/chat/android/client/parser/DateAdapter.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/parser/DateAdapter.kt
@@ -1,6 +1,5 @@
 package io.getstream.chat.android.client.parser
 
-import com.google.gson.Gson
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
@@ -9,9 +8,10 @@ import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
 
-internal class DateAdapter(val gson: Gson) : TypeAdapter<Date>() {
+private const val DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+internal class DateAdapter() : TypeAdapter<Date>() {
 
-    val dateFormat = SimpleDateFormat(ChatParser.DATE_FORMAT, Locale.getDefault()).apply {
+    private val dateFormat = SimpleDateFormat(DATE_FORMAT, Locale.getDefault()).apply {
         timeZone = TimeZone.getTimeZone("UTC")
     }
 

--- a/library/src/main/java/io/getstream/chat/android/client/parser/TypeAdapterFactory.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/parser/TypeAdapterFactory.kt
@@ -27,7 +27,7 @@ class TypeAdapterFactory : com.google.gson.TypeAdapterFactory {
                 ) as TypeAdapter<T>
             }
             Date::class.java -> {
-                DateAdapter(gson) as TypeAdapter<T>
+                DateAdapter() as TypeAdapter<T>
             }
             FilterObject::class.java -> {
                 FilterObjectAdapter(gson) as TypeAdapter<T>

--- a/library/src/test/java/io/getstream/chat/android/client/parser/DateAdapterTest.kt
+++ b/library/src/test/java/io/getstream/chat/android/client/parser/DateAdapterTest.kt
@@ -1,0 +1,37 @@
+package io.getstream.chat.android.client.parser
+
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import org.junit.Assert
+import org.junit.Test
+import java.io.StringReader
+import java.io.StringWriter
+import java.util.Date
+
+internal class DateAdapterTest {
+
+    private val dateAdapter = DateAdapter()
+
+    @Test
+    fun readTest() {
+        Assert.assertEquals(1593411268000, dateAdapter.read(JsonReader(StringReader("\"2020-06-29T06:14:28Z\"")))?.time)
+        Assert.assertEquals(1593411268000, dateAdapter.read(JsonReader(StringReader("\"2020-06-29T06:14:28.0Z\"")))?.time)
+        Assert.assertEquals(1593411268000, dateAdapter.read(JsonReader(StringReader("\"2020-06-29T06:14:28.00Z\"")))?.time)
+        Assert.assertEquals(1593411268000, dateAdapter.read(JsonReader(StringReader("\"2020-06-29T06:14:28.000Z\"")))?.time)
+        Assert.assertEquals(1593411268100, dateAdapter.read(JsonReader(StringReader("\"2020-06-29T06:14:28.100Z\"")))?.time)
+        Assert.assertNull(dateAdapter.read(JsonReader(StringReader(""))))
+    }
+
+    @Test
+    fun writeTest() {
+        var stringWriter = StringWriter()
+        var jsonWriter = JsonWriter(stringWriter)
+        dateAdapter.write(jsonWriter, Date(1593411268000))
+        Assert.assertEquals("\"2020-06-29T06:14:28.000Z\"", stringWriter.toString())
+
+        stringWriter = StringWriter()
+        jsonWriter = JsonWriter(stringWriter)
+        dateAdapter.write(jsonWriter, null)
+        Assert.assertEquals("null", stringWriter.toString())
+    }
+}


### PR DESCRIPTION
Dates received from backend could haver or not have nanoseconds and both are right according to rfc3339 standard.
We need to handle that