### PR TITLE
Apply KtLint Plugin to Root of the Project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+apply plugin: "org.jlleitschuh.gradle.ktlint"
 buildscript {
     ext {
         kotlin_version = '1.3.72'


### PR DESCRIPTION
Apply KtLint Plugin to Root of the Project to add some extra gradle tasks like `ktlintApplyToIdea` that help us to apply Kotlin CheckStyle into our AndroidStudio configuration