### PR TITLE
Improve Request latency

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+# 1.13.2 - Fri 14 Aug 2020
+
+- Reduce TLS Latency
+
 # 1.13.1 - Fri 7 Aug 2020
 
 - Fix DateParser

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,7 +15,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
-        versionName "1.13.1"
+        versionName "1.13.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/library/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -267,6 +267,7 @@ interface ChatClient {
         private var baseTimeout = 10000L
         private var cdnTimeout = 10000L
         private var logLevel = ChatLogLevel.ALL
+        private var warmUp: Boolean = true
         private var loggerHandler: ChatLoggerHandler? = null
         private lateinit var notificationsConfig: ChatNotificationConfig
 
@@ -303,6 +304,10 @@ interface ChatClient {
         fun cdnTimeout(timeout: Long): Builder {
             cdnTimeout = timeout
             return this
+        }
+
+        fun disableWarmUp(): Builder = apply {
+            warmUp = false
         }
 
         fun baseUrl(value: String): Builder {
@@ -352,6 +357,7 @@ interface ChatClient {
                 "wss://$baseUrl/",
                 baseTimeout,
                 cdnTimeout,
+                warmUp,
                 ChatLogger.Config(logLevel, loggerHandler),
                 notificationsConfig
             )

--- a/library/src/main/java/io/getstream/chat/android/client/ChatClientImpl.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/ChatClientImpl.kt
@@ -89,6 +89,7 @@ internal class ChatClientImpl(
         connectionListener = listener
         config.isAnonymous = false
         config.tokenManager.setTokenProvider(ImmediateTokenProvider(token))
+        warmUp()
         notifications.onSetUser()
         getTokenAndConnect {
             socket.connect(user)
@@ -99,6 +100,7 @@ internal class ChatClientImpl(
         connectionListener = listener
         config.isAnonymous = false
         config.tokenManager.setTokenProvider(tokenProvider)
+        warmUp()
         notifications.onSetUser()
         getTokenAndConnect {
             socket.connect(user)
@@ -108,6 +110,7 @@ internal class ChatClientImpl(
     override fun setAnonymousUser(listener: InitConnectionListener?) {
         connectionListener = listener
         config.isAnonymous = true
+        warmUp()
         notifications.onSetUser()
         getTokenAndConnect {
             socket.connectAnonymously()
@@ -547,5 +550,9 @@ internal class ChatClientImpl(
         config.tokenManager.loadAsync {
             connect()
         }
+    }
+
+    private fun warmUp() {
+        api.warmUp()
     }
 }

--- a/library/src/main/java/io/getstream/chat/android/client/ChatClientImpl.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/ChatClientImpl.kt
@@ -553,6 +553,8 @@ internal class ChatClientImpl(
     }
 
     private fun warmUp() {
-        api.warmUp()
+        if (config.warmUp) {
+            api.warmUp()
+        }
     }
 }

--- a/library/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -195,4 +195,6 @@ interface ChatApi {
     fun muteChannel(channelType: String, channelId: String): Call<Unit>
 
     fun unMuteChannel(channelType: String, channelId: String): Call<Unit>
+
+    fun warmUp()
 }

--- a/library/src/main/java/io/getstream/chat/android/client/api/ChatApiImpl.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/api/ChatApiImpl.kt
@@ -784,6 +784,10 @@ internal class ChatApiImpl(
         }
     }
 
+    override fun warmUp() {
+        callMapper.map(retrofitApi.warmUp()).enqueue { }
+    }
+
     private fun <T> noConnectionIdError(): ErrorCall<T> {
         return ErrorCall(ChatError("setUser is either not called or not finished"))
     }

--- a/library/src/main/java/io/getstream/chat/android/client/api/ChatClientConfig.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/api/ChatClientConfig.kt
@@ -12,6 +12,7 @@ internal class ChatClientConfig(
     var wssUrl: String,
     var baseTimeout: Long,
     var cdnTimeout: Long,
+    val warmUp: Boolean,
     val loggerConfig: ChatLogger.Config,
     val notificationsConfig: ChatNotificationConfig,
     val tokenManager: TokenManager = TokenManagerImpl()

--- a/library/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
@@ -41,10 +41,12 @@ import io.getstream.chat.android.client.api.models.UpdateChannelRequest
 import io.getstream.chat.android.client.api.models.UpdateUsersRequest
 import io.getstream.chat.android.client.api.models.UpdateUsersResponse
 import io.getstream.chat.android.client.parser.UrlQueryPayload
+import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.OPTIONS
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -426,4 +428,7 @@ interface RetrofitApi {
         @Query("user_id") userId: String,
         @Query("connection_id") connectionId: String
     ): Call<GetSyncHistoryResponse>
+
+    @OPTIONS("/connect")
+    fun warmUp(): Call<ResponseBody>
 }

--- a/library/src/test/java/io/getstream/chat/android/client/MockClientBuilder.kt
+++ b/library/src/test/java/io/getstream/chat/android/client/MockClientBuilder.kt
@@ -57,6 +57,7 @@ class MockClientBuilder {
             "socket.url",
             1000,
             1000,
+            false,
             ChatLogger.Config(ChatLogLevel.NOTHING, null),
             ChatNotificationConfig(context)
         )

--- a/library/src/test/java/io/getstream/chat/android/client/api/ClientConnectionTests.kt
+++ b/library/src/test/java/io/getstream/chat/android/client/api/ClientConnectionTests.kt
@@ -36,6 +36,7 @@ internal class ClientConnectionTests {
         "socket.url",
         1000,
         1000,
+        false,
         ChatLogger.Config(ChatLogLevel.NOTHING, null),
         ChatNotificationConfig(context),
         FakeTokenManager(token)


### PR DESCRIPTION
To improve Request Latency a connection request is done while WS connection is established, the TLS Handshake is done on this first call and kept for the following request to the server, reducing drastically the request latency