### PR TITLE
Refactor update-channel method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+# 1.13.3 - Tue 18 Aug 2020
+
+- Set message as optional when updating a channel
+
 # 1.13.2 - Fri 14 Aug 2020
 
 - Reduce TLS Latency

--- a/library/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -228,7 +228,7 @@ interface ChatClient {
     fun updateChannel(
         channelType: String,
         channelId: String,
-        updateMessage: Message,
+        updateMessage: Message? = null,
         channelExtraData: Map<String, Any> = emptyMap()
     ): Call<Channel>
 

--- a/library/src/main/java/io/getstream/chat/android/client/ChatClientImpl.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/ChatClientImpl.kt
@@ -338,16 +338,10 @@ internal class ChatClientImpl(
     override fun updateChannel(
         channelType: String,
         channelId: String,
-        updateMessage: Message,
+        updateMessage: Message?,
         channelExtraData: Map<String, Any>
-    ): Call<Channel> {
-
-        val toMutableMap = channelExtraData.toMutableMap()
-        toMutableMap.remove("members")
-
-        val request = UpdateChannelRequest(channelExtraData, updateMessage)
-        return api.updateChannel(channelType, channelId, request)
-    }
+    ): Call<Channel> =
+        api.updateChannel(channelType, channelId, UpdateChannelRequest(channelExtraData, updateMessage))
 
     override fun rejectInvite(channelType: String, channelId: String): Call<Channel> {
         return api.rejectInvite(channelType, channelId)

--- a/library/src/main/java/io/getstream/chat/android/client/api/models/UpdateChannelRequest.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/api/models/UpdateChannelRequest.kt
@@ -2,4 +2,4 @@ package io.getstream.chat.android.client.api.models
 
 import io.getstream.chat.android.client.models.Message
 
-data class UpdateChannelRequest(val data: Map<String, Any>, val message: Message)
+data class UpdateChannelRequest(val data: Map<String, Any>, val message: Message?)

--- a/library/src/main/java/io/getstream/chat/android/client/controllers/ChannelController.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/controllers/ChannelController.kt
@@ -47,7 +47,7 @@ interface ChannelController {
     fun getReactions(messageId: String, offset: Int, limit: Int): Call<List<Reaction>>
     fun getReactions(messageId: String, firstReactionId: String, limit: Int): Call<List<Message>>
     fun events(): ChatObservable
-    fun update(message: Message, extraData: Map<String, Any> = emptyMap()): Call<Channel>
+    fun update(message: Message? = null, extraData: Map<String, Any> = emptyMap()): Call<Channel>
     fun addMembers(vararg userIds: String): Call<Channel>
     fun removeMembers(vararg userIds: String): Call<Channel>
     fun acceptInvite(message: String): Call<Channel>

--- a/library/src/main/java/io/getstream/chat/android/client/controllers/ChannelControllerImpl.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/controllers/ChannelControllerImpl.kt
@@ -141,7 +141,7 @@ internal class ChannelControllerImpl(
         return client.getRepliesMore(messageId, firstReactionId, limit)
     }
 
-    override fun update(message: Message, extraData: Map<String, Any>): Call<Channel> {
+    override fun update(message: Message?, extraData: Map<String, Any>): Call<Channel> {
         return client.updateChannel(channelType, channelId, message, extraData)
     }
 


### PR DESCRIPTION
The `Message` parameter is not mandatory when a channel is updated, so now it is an optional parameters on the public API of our LLC SDK