### PR TITLE
Fix CreateChannel methods

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 # To be released:
 
 - Decouple cloud messages handler logic from configuration data
+- Fix createChannel methods
 
 # 1.13.3 - Tue 18 Aug 2020
 

--- a/library/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -74,8 +74,6 @@ interface ChatClient {
         extraData: Map<String, Any>
     ): Call<Channel>
 
-    fun createChannel(channelType: String, extraData: Map<String, Any>): Call<Channel>
-
     fun createChannel(channelType: String, channelId: String, extraData: Map<String, Any>): Call<Channel>
 
     fun muteChannel(channelType: String, channelId: String): Call<Unit>

--- a/library/src/main/java/io/getstream/chat/android/client/ChatClientImpl.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/ChatClientImpl.kt
@@ -40,7 +40,6 @@ import io.getstream.chat.android.client.utils.ProgressCallback
 import io.getstream.chat.android.client.utils.observable.ChatObservable
 import java.io.File
 import java.util.Date
-import kotlin.collections.set
 
 internal class ChatClientImpl(
     private val config: ChatClientConfig,
@@ -490,40 +489,28 @@ internal class ChatClientImpl(
         return channel(type, id)
     }
 
-    override fun createChannel(channelType: String, extraData: Map<String, Any>): Call<Channel> {
-        return createChannel(channelType, "", extraData)
-    }
+    override fun createChannel(channelType: String, extraData: Map<String, Any>): Call<Channel> =
+        createChannel(channelType, "", emptyList(), extraData)
 
-    override fun createChannel(channelType: String, channelId: String, extraData: Map<String, Any>): Call<Channel> {
-        val request = QueryChannelRequest().withData(extraData)
-        return queryChannel(channelType, channelId, request)
-    }
+    override fun createChannel(channelType: String, channelId: String, extraData: Map<String, Any>): Call<Channel> =
+        createChannel(channelType, channelId, emptyList(), extraData)
 
-    override fun createChannel(channelType: String, channelId: String, members: List<String>): Call<Channel> {
-        return createChannel(channelType, channelId, mapOf(Pair(ModelFields.MEMBERS, members)))
-    }
+    override fun createChannel(channelType: String, channelId: String, members: List<String>): Call<Channel> =
+        createChannel(channelType, channelId, members, emptyMap())
 
-    override fun createChannel(channelType: String, members: List<String>): Call<Channel> {
-        return createChannel(channelType, "", members)
-    }
+    override fun createChannel(channelType: String, members: List<String>): Call<Channel> =
+        createChannel(channelType, "", members, emptyMap())
 
-    override fun createChannel(channelType: String, members: List<String>, extraData: Map<String, Any>): Call<Channel> {
-        return createChannel(channelType, members)
-    }
+    override fun createChannel(channelType: String, members: List<String>, extraData: Map<String, Any>): Call<Channel> =
+        createChannel(channelType, "", members, extraData)
 
     override fun createChannel(
         channelType: String,
         channelId: String,
         members: List<String>,
         extraData: Map<String, Any>
-    ): Call<Channel> {
-
-        val dataWithMembers = extraData.toMutableMap()
-        dataWithMembers[ModelFields.MEMBERS] = members
-
-        val request = QueryChannelRequest().withData(dataWithMembers)
-        return queryChannel(channelType, channelId, request)
-    }
+    ): Call<Channel> =
+        queryChannel(channelType, channelId, QueryChannelRequest().withData(extraData + mapOf(ModelFields.MEMBERS to members)))
 
     override fun getSyncHistory(channelsIds: List<String>, lastSyncAt: Date): Call<List<ChatEvent>> {
         return api.getSyncHistory(channelsIds, lastSyncAt)

--- a/library/src/main/java/io/getstream/chat/android/client/ChatClientImpl.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/ChatClientImpl.kt
@@ -489,9 +489,6 @@ internal class ChatClientImpl(
         return channel(type, id)
     }
 
-    override fun createChannel(channelType: String, extraData: Map<String, Any>): Call<Channel> =
-        createChannel(channelType, "", emptyList(), extraData)
-
     override fun createChannel(channelType: String, channelId: String, extraData: Map<String, Any>): Call<Channel> =
         createChannel(channelType, channelId, emptyList(), extraData)
 


### PR DESCRIPTION
There was an issue creating a channel without id.
All `createChannel()` methods have been updated to use a common method with the needed attributes