### PR TITLE
Members Limit

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 - `ChannelResponse.watchers` is an array of User now
 - `Watcher` model has been removed, `User` model should be used instead
+- `QueryChannelsRequet` has a new field called `memberLimit` to limit the number of members received per channel
 
 # 1.15.1 - Thu 28 Aug 2020
 

--- a/library/src/main/java/io/getstream/chat/android/client/api/models/QueryChannelsRequest.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/api/models/QueryChannelsRequest.kt
@@ -5,14 +5,12 @@ import io.getstream.chat.android.client.parser.IgnoreSerialisation
 import io.getstream.chat.android.client.utils.FilterObject
 
 class QueryChannelsRequest(
-    @IgnoreSerialisation
-    val filter: FilterObject,
+    @IgnoreSerialisation val filter: FilterObject,
     var offset: Int,
     var limit: Int,
-    @IgnoreSerialisation
-    val querySort: QuerySort = QuerySort(),
-    @SerializedName("message_limit")
-    var messageLimit: Int = 0
+    @IgnoreSerialisation val querySort: QuerySort = QuerySort(),
+    @SerializedName("message_limit") var messageLimit: Int = 0,
+    @SerializedName("member_limit") var memberLimit: Int = 0
 ) : ChannelRequest<QueryChannelsRequest> {
 
     override var state: Boolean = true

--- a/sample/src/main/java/io/getstream/chat/android/client/sample/DocumentationSamplesJava.java
+++ b/sample/src/main/java/io/getstream/chat/android/client/sample/DocumentationSamplesJava.java
@@ -741,8 +741,9 @@ public class DocumentationSamplesJava {
                 int offset = 0;
                 int limit = 10;
                 int messageLimit = 10;
+                int memberLimit = 10;
                 QuerySort sort = new QuerySort().desc("last_message_at");
-                QueryChannelsRequest request = new QueryChannelsRequest(filter, offset, limit, sort, messageLimit);
+                QueryChannelsRequest request = new QueryChannelsRequest(filter, offset, limit, sort, messageLimit, memberLimit);
                 request.setWatch(true);
                 request.setState(true);
 
@@ -773,9 +774,10 @@ public class DocumentationSamplesJava {
                 int offset = 0;
                 int limit = 10;
                 int messageLimit = 10;
+                int memberLimit = 10;
                 QuerySort sort = new QuerySort();
 
-                QueryChannelsRequest request = new QueryChannelsRequest(filter, offset, limit, sort, messageLimit);
+                QueryChannelsRequest request = new QueryChannelsRequest(filter, offset, limit, sort, messageLimit, memberLimit);
 
                 client.queryChannels(request).enqueue(result -> {
                     List<Channel> channels = result.data();
@@ -914,9 +916,10 @@ public class DocumentationSamplesJava {
                 int offset = 0;
                 int limit = 10;
                 int messageLimit = 10;
+                int memberLimit = 10;
                 QuerySort sort = new QuerySort();
 
-                QueryChannelsRequest request = new QueryChannelsRequest(filter, offset, limit, sort, messageLimit);
+                QueryChannelsRequest request = new QueryChannelsRequest(filter, offset, limit, sort, messageLimit, memberLimit);
 
                 client.queryChannels(request).enqueue(result -> {
                     List<Channel> channels = result.data();
@@ -929,9 +932,10 @@ public class DocumentationSamplesJava {
                 int offset = 0;
                 int limit = 10;
                 int messageLimit = 10;
+                int memberLimit = 10;
                 QuerySort sort = new QuerySort();
 
-                QueryChannelsRequest request = new QueryChannelsRequest(filter, offset, limit, sort, messageLimit);
+                QueryChannelsRequest request = new QueryChannelsRequest(filter, offset, limit, sort, messageLimit, memberLimit);
 
                 client.queryChannels(request).enqueue(result -> {
                     List<Channel> channels = result.data();
@@ -1000,12 +1004,13 @@ public class DocumentationSamplesJava {
                 int offset = 0;
                 int limit = 10;
                 int messageLimit = 0;
+                int memberLimit = 0;
                 QuerySort sort = new QuerySort();
 
                 FilterObject mutedFiler = eq("muted", false);
 
                 client.queryChannels(
-                        new QueryChannelsRequest(mutedFiler, offset, limit, sort, messageLimit)
+                        new QueryChannelsRequest(mutedFiler, offset, limit, sort, messageLimit, memberLimit)
                 ).enqueue(result -> {
                     if (result.isSuccess()) {
                         List<Channel> channels = result.data();
@@ -1020,7 +1025,7 @@ public class DocumentationSamplesJava {
                 FilterObject unmutedFilter = eq("muted", true);
 
                 client.queryChannels(
-                        new QueryChannelsRequest(unmutedFilter, offset, limit, sort, messageLimit)
+                        new QueryChannelsRequest(unmutedFilter, offset, limit, sort, messageLimit, memberLimit)
                 ).enqueue(result -> {
                     if (result.isSuccess()) {
                         List<Channel> channels = result.data();


### PR DESCRIPTION
`QueryChannelsRequet` has a new field called `memberLimit` to limit the number of members received per channel