### PR TITLE
Hotfix/events parser

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 - Add send action operation to ChannelController
 - Fix serialized file names of SendActionRequest
+- Fix `ConnectedEvent` parse process
 
 # 1.15.2 - Tue 1 Sep 2020
 

--- a/library/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
@@ -452,6 +452,6 @@ data class ErrorEvent(
 
 data class UnknownEvent(
     override val type: String,
-    override val createdAt: Date,
+    @SerializedName("created_at") override val createdAt: Date,
     val rawData: Map<*, *>
 ) : ChatEvent()

--- a/library/src/main/java/io/getstream/chat/android/client/parser/EventAdapter.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/parser/EventAdapter.kt
@@ -81,8 +81,8 @@ internal class EventAdapter(
 
         val mapAdapter = gson.getAdapter(HashMap::class.java)
 
-        val mapData = mapAdapter.read(reader) as HashMap<*, *>
-        val type = mapData["type"] as String
+        val mapData = (mapAdapter.read(reader) as HashMap<*, *>).filterNot { it.value == null }
+        val type = mapData["type"] as? String
         val data = gson.toJson(mapData)
 
         return when (type) {

--- a/library/src/main/java/io/getstream/chat/android/client/parser/EventAdapter.kt
+++ b/library/src/main/java/io/getstream/chat/android/client/parser/EventAdapter.kt
@@ -54,7 +54,6 @@ import io.getstream.chat.android.client.events.UserUpdatedEvent
 import io.getstream.chat.android.client.events.UsersMutedEvent
 import io.getstream.chat.android.client.events.UsersUnmutedEvent
 import io.getstream.chat.android.client.models.EventType
-import java.util.Date
 
 internal class EventAdapter(
     private val gson: Gson,
@@ -280,7 +279,11 @@ internal class EventAdapter(
                 }
             }
             else -> {
-                UnknownEvent(mapData["type"]?.toString() ?: EventType.UNKNOWN, Date(), mapData)
+                gson.fromJson(data, UnknownEvent::class.java)
+                    .copy(
+                        type = mapData["type"]?.toString() ?: EventType.UNKNOWN,
+                        rawData = mapData
+                    )
             }
         }
     }

--- a/library/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
+++ b/library/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
@@ -512,11 +512,14 @@ fun createNewMessageEventStringJson() =
         """.trimIndent()
     )
 
-private fun createChatEventStringJson(type: String, payload: String) =
+fun createUnknownEventStringJson(type: String = "unknown_event") =
+    createChatEventStringJson(type, null)
+
+private fun createChatEventStringJson(type: String, payload: String?) =
     """
         {"type": "$type",
-         "created_at": "2020-06-29T06:14:28.000Z",
-         $payload
+         "created_at": "2020-06-29T06:14:28.000Z"
+         ${payload?.let { ", $it" } ?: ""}
          }
     """.trimIndent()
 

--- a/library/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
+++ b/library/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
@@ -472,12 +472,12 @@ fun createHealthEventStringJson() =
         """.trimIndent()
     )
 
-fun createConnectedEventStringJson() =
+fun createConnectedEventStringJson(userJsonString: String? = createUserJsonString()) =
     createChatEventStringJson(
         "health.check",
         """
             "connection_id":"6cfffec7-40df-40ac-901a-6ea6c5b7fb83",
-            "me": ${createUserJsonString()}
+            "me": $userJsonString
         """.trimIndent()
     )
 

--- a/library/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
+++ b/library/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
@@ -38,6 +38,7 @@ import io.getstream.chat.android.client.createReactionNewEventStringJson
 import io.getstream.chat.android.client.createReactionUpdateEventStringJson
 import io.getstream.chat.android.client.createTypingStartEventStringJson
 import io.getstream.chat.android.client.createTypingStopEventStringJson
+import io.getstream.chat.android.client.createUnknownEventStringJson
 import io.getstream.chat.android.client.createUserDeletedEventStringJson
 import io.getstream.chat.android.client.createUserMutedEventStringJson
 import io.getstream.chat.android.client.createUserPresenceChangedEventStringJson
@@ -85,6 +86,7 @@ import io.getstream.chat.android.client.events.ReactionNewEvent
 import io.getstream.chat.android.client.events.ReactionUpdateEvent
 import io.getstream.chat.android.client.events.TypingStartEvent
 import io.getstream.chat.android.client.events.TypingStopEvent
+import io.getstream.chat.android.client.events.UnknownEvent
 import io.getstream.chat.android.client.events.UserDeletedEvent
 import io.getstream.chat.android.client.events.UserMutedEvent
 import io.getstream.chat.android.client.events.UserPresenceChangedEvent
@@ -108,6 +110,7 @@ import java.util.Date
 
 object EventArguments {
     private val date = Date(1593411268000)
+    private val dateString = "2020-06-29T06:14:28.000Z"
     private val connectionId = "6cfffec7-40df-40ac-901a-6ea6c5b7fb83"
     private val channelType = "channelType"
     private val channelId = "channelId"
@@ -220,6 +223,8 @@ object EventArguments {
     private val notificationChannelMutesUpdatedEvent = NotificationChannelMutesUpdatedEvent(EventType.NOTIFICATION_CHANNEL_MUTES_UPDATED, date, user)
     private val notificationMutesUpdatedEvent = NotificationMutesUpdatedEvent(EventType.NOTIFICATION_MUTES_UPDATED, date, user)
     private val newMessageEvent = NewMessageEvent(EventType.MESSAGE_NEW, date, user, cid, channelType, channelId, message, watcherCount, unreadMessages, totalUnreadCount)
+    private val unknownEvent = UnknownEvent(EventType.UNKNOWN, date, mapOf("type" to EventType.UNKNOWN, "created_at" to dateString))
+    private val otherUnknownEvent = UnknownEvent("some.unknown.type", date, mapOf("type" to "some.unknown.type", "created_at" to dateString))
 
     private fun eventArguments() = listOf(
         Arguments.of(createChannelTruncatedEventStringJson(), ChannelTruncatedEvent::class.java, channelTruncatedEvent),
@@ -269,7 +274,9 @@ object EventArguments {
         Arguments.of(createHealthEventStringJson(), HealthEvent::class.java, healthEvent),
         Arguments.of(createNotificationChannelMutesUpdatedEventStringJson(), NotificationChannelMutesUpdatedEvent::class.java, notificationChannelMutesUpdatedEvent),
         Arguments.of(createNotificationMutesUpdatedEventStringJson(), NotificationMutesUpdatedEvent::class.java, notificationMutesUpdatedEvent),
-        Arguments.of(createNewMessageEventStringJson(), NewMessageEvent::class.java, newMessageEvent)
+        Arguments.of(createNewMessageEventStringJson(), NewMessageEvent::class.java, newMessageEvent),
+        Arguments.of(createUnknownEventStringJson(), UnknownEvent::class.java, unknownEvent),
+        Arguments.of(createUnknownEventStringJson("some.unknown.type"), UnknownEvent::class.java, otherUnknownEvent)
     )
 
     @JvmStatic

--- a/library/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
+++ b/library/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
@@ -260,6 +260,7 @@ object EventArguments {
         Arguments.of(createUsersUnmutedEventStringJson(), UsersUnmutedEvent::class.java, usersUnmutedEvent),
         Arguments.of(createUserUpdatedEventStringJson(), UserUpdatedEvent::class.java, userUpdatedEvent),
         Arguments.of(createConnectedEventStringJson(), ConnectedEvent::class.java, connectedEvent),
+        Arguments.of(createConnectedEventStringJson(null), ConnectedEvent::class.java, healthEvent),
         Arguments.of(createChannelCreatedEventStringJson(), ChannelCreatedEvent::class.java, channelCreatedEvent),
         Arguments.of(createChannelDeletedEventStringJson(), ChannelDeletedEvent::class.java, channelDeletedEvent),
         Arguments.of(createChannelHiddenEventStringJson(), ChannelHiddenEvent::class.java, channelHiddenEvent),


### PR DESCRIPTION
`health.check` come from the API with two different structure to notify us about two different event: `ConnectedEvent` and `HealthEvent`. The only difference between both of them is that `ConnectedEvent` add a property `User` about the current user logged in. This field is only mandatory on the first `health.check` event we receive, on the rest it could be null and needs to be handled on our new `ChatEvent` parse process.
`UnknownEvent` parse process has been improved as well