### PR TITLE
Update events fields related to read status

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 # To be released:
 
-- Update events fields related to read status
+- Update events fields related to read status - remove "unread_messages" field and add "unread_channels" to NewMessageEvent, NotificationMarkReadEvent, and NotificationMessageNewEvent
 
 # 1.15.4 - Fri 11 Sep 2020
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 # To be released:
 
+- Update events fields related to read status
+
 # 1.15.4 - Fri 11 Sep 2020
 
 - Fix Socket Disconnection

--- a/client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
@@ -180,7 +180,6 @@ data class NewMessageEvent(
     @SerializedName("channel_id") val channelId: String,
     val message: Message,
     @SerializedName("watcher_count") val watcherCount: Int?,
-    @SerializedName("unread_messages") val unreadMessages: Int?,
     @SerializedName("total_unread_count") val totalUnreadCount: Int?,
     @SerializedName("unread_channels" ) val unreadChannels: Int?
 ) : CidEvent()
@@ -248,7 +247,6 @@ data class NotificationMarkReadEvent(
     @SerializedName("channel_type") val channelType: String,
     @SerializedName("channel_id") val channelId: String,
     @SerializedName("watcher_count") val watcherCount: Int?,
-    @SerializedName("unread_messages") val unreadMessages: Int?,
     @SerializedName("total_unread_count") val totalUnreadCount: Int?,
     @SerializedName("unread_channels" ) val unreadChannels: Int?
 ) : CidEvent()
@@ -262,7 +260,6 @@ data class NotificationMessageNewEvent(
     @SerializedName("channel_id") val channelId: String,
     val message: Message,
     @SerializedName("watcher_count") val watcherCount: Int?,
-    @SerializedName("unread_messages") val unreadMessages: Int?,
     @SerializedName("total_unread_count") val totalUnreadCount: Int?,
     @SerializedName("unread_channels" ) val unreadChannels: Int?
 ) : CidEvent()

--- a/client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
@@ -181,7 +181,8 @@ data class NewMessageEvent(
     val message: Message,
     @SerializedName("watcher_count") val watcherCount: Int?,
     @SerializedName("unread_messages") val unreadMessages: Int?,
-    @SerializedName("total_unread_count") val totalUnreadCount: Int?
+    @SerializedName("total_unread_count") val totalUnreadCount: Int?,
+    @SerializedName("unread_channels" ) val unreadChannels: Int?
 ) : CidEvent()
 
 data class NotificationAddedToChannelEvent(
@@ -248,7 +249,8 @@ data class NotificationMarkReadEvent(
     @SerializedName("channel_id") val channelId: String,
     @SerializedName("watcher_count") val watcherCount: Int?,
     @SerializedName("unread_messages") val unreadMessages: Int?,
-    @SerializedName("total_unread_count") val totalUnreadCount: Int?
+    @SerializedName("total_unread_count") val totalUnreadCount: Int?,
+    @SerializedName("unread_channels" ) val unreadChannels: Int?
 ) : CidEvent()
 
 data class NotificationMessageNewEvent(
@@ -261,7 +263,8 @@ data class NotificationMessageNewEvent(
     val message: Message,
     @SerializedName("watcher_count") val watcherCount: Int?,
     @SerializedName("unread_messages") val unreadMessages: Int?,
-    @SerializedName("total_unread_count") val totalUnreadCount: Int?
+    @SerializedName("total_unread_count") val totalUnreadCount: Int?,
+    @SerializedName("unread_channels" ) val unreadChannels: Int?
 ) : CidEvent()
 
 data class NotificationMutesUpdatedEvent(

--- a/client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
@@ -181,7 +181,7 @@ data class NewMessageEvent(
     val message: Message,
     @SerializedName("watcher_count") val watcherCount: Int?,
     @SerializedName("total_unread_count") val totalUnreadCount: Int?,
-    @SerializedName("unread_channels" ) val unreadChannels: Int?
+    @SerializedName("unread_channels") val unreadChannels: Int?
 ) : CidEvent()
 
 data class NotificationAddedToChannelEvent(
@@ -248,7 +248,7 @@ data class NotificationMarkReadEvent(
     @SerializedName("channel_id") val channelId: String,
     @SerializedName("watcher_count") val watcherCount: Int?,
     @SerializedName("total_unread_count") val totalUnreadCount: Int?,
-    @SerializedName("unread_channels" ) val unreadChannels: Int?
+    @SerializedName("unread_channels") val unreadChannels: Int?
 ) : CidEvent()
 
 data class NotificationMessageNewEvent(
@@ -261,7 +261,7 @@ data class NotificationMessageNewEvent(
     val message: Message,
     @SerializedName("watcher_count") val watcherCount: Int?,
     @SerializedName("total_unread_count") val totalUnreadCount: Int?,
-    @SerializedName("unread_channels" ) val unreadChannels: Int?
+    @SerializedName("unread_channels") val unreadChannels: Int?
 ) : CidEvent()
 
 data class NotificationMutesUpdatedEvent(

--- a/client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
+++ b/client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
@@ -249,8 +249,8 @@ fun createNotificationMarkReadEventStringJson() =
             "cid": "channelType:channelId",
             "user": ${createUserJsonString()},
             "watcher_count": 3,
-            "unread_messages": 5,
-            "total_unread_count": 4
+            "total_unread_count": 4,
+            "unread_channels": 5
         """.trimIndent()
     )
 
@@ -263,8 +263,8 @@ fun createNotificationMessageNewEventStringJson() =
             "channel_id": "channelId",
             "cid": "channelType:channelId",
             "watcher_count": 3,
-            "unread_messages": 5,
             "total_unread_count": 4,
+            "unread_channels": 5,
             "message": ${createMessageJsonString()}
         """.trimIndent()
     )
@@ -506,8 +506,8 @@ fun createNewMessageEventStringJson() =
             "channel_id": "channelId",
             "cid": "channelType:channelId",
             "watcher_count": 3,
-            "unread_messages": 5,
             "total_unread_count": 4,
+            "unread_channels": 5,
             "message": ${createMessageJsonString()}
         """.trimIndent()
     )

--- a/client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
+++ b/client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
@@ -116,7 +116,7 @@ object EventArguments {
     private val channelId = "channelId"
     private val cid = "channelType:channelId"
     private val watcherCount = 3
-    private val unreadMessages = 5
+    private val unreadChannels = 5
     private val totalUnreadCount = 4
     private val user = User(
         id = "bender",
@@ -197,8 +197,8 @@ object EventArguments {
     private val notificationChannelTruncatedEvent = NotificationChannelTruncatedEvent(EventType.NOTIFICATION_CHANNEL_TRUNCATED, date, cid, channelType, channelId, user, channel)
     private val notificationInviteAcceptedEvent = NotificationInviteAcceptedEvent(EventType.NOTIFICATION_INVITE_ACCEPTED, date, cid, channelType, channelId, user, member)
     private val notificationInvitedEvent = NotificationInvitedEvent(EventType.NOTIFICATION_INVITED, date, cid, channelType, channelId, user, member)
-    private val notificationMarkReadEvent = NotificationMarkReadEvent(EventType.NOTIFICATION_MARK_READ, date, user, cid, channelType, channelId, watcherCount, unreadMessages, totalUnreadCount)
-    private val notificationMessageNewEvent = NotificationMessageNewEvent(EventType.NOTIFICATION_MESSAGE_NEW, date, user, cid, channelType, channelId, message, watcherCount, unreadMessages, totalUnreadCount)
+    private val notificationMarkReadEvent = NotificationMarkReadEvent(EventType.NOTIFICATION_MARK_READ, date, user, cid, channelType, channelId, watcherCount, totalUnreadCount, unreadChannels)
+    private val notificationMessageNewEvent = NotificationMessageNewEvent(EventType.NOTIFICATION_MESSAGE_NEW, date, user, cid, channelType, channelId, message, watcherCount, totalUnreadCount, unreadChannels)
     private val notificationRemovedFromChannelEvent = NotificationRemovedFromChannelEvent(EventType.NOTIFICATION_REMOVED_FROM_CHANNEL, date, user, cid, channelType, channelId)
     private val reactionDeletedEvent = ReactionDeletedEvent(EventType.REACTION_DELETED, date, user, cid, channelType, channelId, message, reaction)
     private val reactionNewEvent = ReactionNewEvent(EventType.REACTION_NEW, date, user, cid, channelType, channelId, message, reaction)
@@ -222,7 +222,7 @@ object EventArguments {
     private val connectedEvent = ConnectedEvent(EventType.HEALTH_CHECK, date, user, connectionId)
     private val notificationChannelMutesUpdatedEvent = NotificationChannelMutesUpdatedEvent(EventType.NOTIFICATION_CHANNEL_MUTES_UPDATED, date, user)
     private val notificationMutesUpdatedEvent = NotificationMutesUpdatedEvent(EventType.NOTIFICATION_MUTES_UPDATED, date, user)
-    private val newMessageEvent = NewMessageEvent(EventType.MESSAGE_NEW, date, user, cid, channelType, channelId, message, watcherCount, unreadMessages, totalUnreadCount)
+    private val newMessageEvent = NewMessageEvent(EventType.MESSAGE_NEW, date, user, cid, channelType, channelId, message, watcherCount, totalUnreadCount, unreadChannels)
     private val unknownEvent = UnknownEvent(EventType.UNKNOWN, date, mapOf("type" to EventType.UNKNOWN, "created_at" to dateString))
     private val otherUnknownEvent = UnknownEvent("some.unknown.type", date, mapOf("type" to "some.unknown.type", "created_at" to dateString))
 


### PR DESCRIPTION
This PR adds missing "unread_channels" field to some of the ChatEvents and removes "unread_messages" which represent the unread messages (in a certain channel) and is only returned when you call queryChannels or GetOrCreateChannel.