### PR TITLE
Chat client proposal

### DIFF
--- a/client/src/main/java/io/getstream/chat/android/client/NewChatClient.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/NewChatClient.kt
@@ -1,0 +1,48 @@
+package io.getstream.chat.android.client
+
+import android.content.Context
+import com.google.firebase.messaging.RemoteMessage
+import io.getstream.chat.android.client.api.ChatClientConfig
+import io.getstream.chat.android.client.api.models.QueryChannelRequest
+import io.getstream.chat.android.client.api.models.QueryChannelsRequest
+import io.getstream.chat.android.client.api.models.QuerySort
+import io.getstream.chat.android.client.api.models.QueryUsersRequest
+import io.getstream.chat.android.client.api.models.SearchMessagesRequest
+import io.getstream.chat.android.client.api.models.SendActionRequest
+import io.getstream.chat.android.client.call.Call
+import io.getstream.chat.android.client.controllers.ChannelController
+import io.getstream.chat.android.client.events.ChatEvent
+import io.getstream.chat.android.client.logger.ChatLogLevel
+import io.getstream.chat.android.client.logger.ChatLogger
+import io.getstream.chat.android.client.logger.ChatLoggerHandler
+import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.client.models.Device
+import io.getstream.chat.android.client.models.Flag
+import io.getstream.chat.android.client.models.GuestUser
+import io.getstream.chat.android.client.models.Member
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.Mute
+import io.getstream.chat.android.client.models.Reaction
+import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.client.notifications.handler.ChatNotificationHandler
+import io.getstream.chat.android.client.socket.InitConnectionListener
+import io.getstream.chat.android.client.socket.SocketListener
+import io.getstream.chat.android.client.token.TokenProvider
+import io.getstream.chat.android.client.utils.FilterObject
+import io.getstream.chat.android.client.utils.ProgressCallback
+import io.getstream.chat.android.client.utils.observable.ChatObservable
+import java.io.File
+import java.util.Date
+
+interface NewChatClient {
+
+    fun setUser(user: User, token: String, listener: InitConnectionListener? = null)
+
+    fun setUser(user: User, tokenProvider: TokenProvider, listener: InitConnectionListener? = null)
+
+    fun sendMessage(channelType: String, channelId: String, message: Message): Call<Message>
+
+    fun getStorageClient(): StorageClient
+
+    //Code is simplified.
+}

--- a/client/src/main/java/io/getstream/chat/android/client/NewChatClientImpl.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/NewChatClientImpl.kt
@@ -1,0 +1,44 @@
+package io.getstream.chat.android.client
+
+import io.getstream.chat.android.client.api.ChatApi
+import io.getstream.chat.android.client.call.Call
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.client.socket.InitConnectionListener
+import io.getstream.chat.android.client.token.TokenProvider
+
+private const val NO_STORAGE_MESSAGE = "No storage was provided. If you want to have storage, provide a storageClient!"
+
+/*
+* That's the only implementation of Chat. Is shouldn't contain any business logic, this class should follow the Delegation patter.
+* The only responsibility of this class is to pass all data to the correct object to handle a specific request, nothing more.
+*
+* This class only defines a contract with the classes inside it, but the actual implementation lives outside of it.
+*
+* If some implementation is not available for this client, than no delegation is done, this way new behaviour can be created
+* by passing different implementations which conforms to the Open Close Principle. This avoid duplication of code and it uses
+* composition over inheritance.
+*/
+
+class NewChatClientImpl(
+    private val api: ChatApi,
+    private val userInitiallizer: UserInitializer,
+    private val storageClient: StorageClient?
+) : NewChatClient {
+
+    override fun setUser(user: User, token: String, listener: InitConnectionListener?) {
+        userInitiallizer.init(user, token, listener)
+    }
+
+    override fun setUser(user: User, tokenProvider: TokenProvider, listener: InitConnectionListener?) {
+        userInitiallizer.init(user, tokenProvider, listener)
+    }
+
+    override fun sendMessage(channelType: String, channelId: String, message: Message): Call<Message> {
+        storageClient?.storeLastMessage(channelType, channelId, message)
+        return api.sendMessage(channelType, channelId, message)
+    }
+
+    //If client would like to use storage, all the logic lives inside the StorageClient.
+    override fun getStorageClient(): StorageClient = storageClient ?: throw IllegalStateException(NO_STORAGE_MESSAGE)
+}

--- a/client/src/main/java/io/getstream/chat/android/client/SimpleChatFactory.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/SimpleChatFactory.kt
@@ -1,0 +1,8 @@
+package io.getstream.chat.android.client
+
+import io.getstream.chat.android.client.api.ChatApi
+
+class SimpleChatFactory {
+    fun create() =
+        NewChatClientImpl(api = ChatApi(), userInitiallizer = UserInitializer(), storageClient = null)
+}

--- a/client/src/main/java/io/getstream/chat/android/client/StorageClient.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/StorageClient.kt
@@ -1,0 +1,19 @@
+package io.getstream.chat.android.client
+
+import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.client.models.Message
+
+/*
+* Although this interface is defined inside the LLC client, the implementation lives inside the LiveData client.
+* This way a user can change between use the LiveData library, or to provide its own storage accordingly to its needs.
+* The LLC just defines the contract for its functionalities, but no implementation, this should be provided some where else.
+*/
+interface StorageClient {
+
+    fun storeChannelState(channel: Channel)
+
+    //Just a method to illustrate a concept
+    fun storeLastMessage(channelType: String, channelId: String, message: Message)
+
+    //Here comes a some methods related to the behaviour of the storage.
+}


### PR DESCRIPTION
# POC - Single implementation of Chat
This is a prof of concept to create a single class to be the Chat interface, instead of one per library. This code doesn't compile and some parts were a lot simplified so the reader can focus in the concept more easily. The goal is not to provide the final solution or to state what is correct or wrong, but to kick start a proposal of change so the team can improve upon and create the final solution. 

Not all the code is inside this PR, another one is open in the live data repository: https://github.com/GetStream/stream-chat-android-livedata/pull/56

## Proposal
### Current situation

Currently there are 3 classes with a very similar behaviour: `ChatImpl`, `ChatDomainImpl` and `ChatClientImpl` also 3 similar interfaces: `Chat`, `ChatDomain`,  `ChatClient` . It is possible to set the user in any of the 3 implementations, there's unread messages in both `ChatDomain` and `Chat` and some other parts of code are present in more than one of the interfaces. A client can be confused between having to use `ChatDomain` or `ChatClient` for a given feature. In conclusion, many instances of the Client can generate problems. 

### Change proposal

So one solution proposed is to use only one interface o Chat that should be used across all the libraries. This interface defined the contracts the other libraries must follow to add new behaviour to the chat. In this example it was named as `NewChatClient` (the name should obviously be changed). 

```
interface NewChatClient {

    fun setUser(user: User, token: String, listener: InitConnectionListener? = null)

    fun setUser(user: User, tokenProvider: TokenProvider, listener: InitConnectionListener? = null)

    fun sendMessage(channelType: String, channelId: String, message: Message): Call<Message>

    fun getStorageClient(): StorageClient

    //Code is simplified.
}

```


Implementations of the `NewChatClient` act only as a Delegator for other classes that will know how to handle requests (Api knows how to set the user in the backend, StorageClient know how to handle persistence...). Those classes act as handlers of the request. 

The delegation can happen or not accordingly to the fact that a given handler was provided or not for that request. So if a client requests for persistence, but no `StorageClient` was provided, the chat returns an error asking for a handler. As the example:

```
class NewChatClientImpl(
    private val api: ChatApi,
    private val userInitiallizer: UserInitializer,
    private val storageClient: StorageClient?
) : NewChatClient {

    override fun setUser(user: User, token: String, listener: InitConnectionListener?) {
        userInitiallizer.init(user, token, listener)
    }

    override fun setUser(user: User, tokenProvider: TokenProvider, listener: InitConnectionListener?) {
        userInitiallizer.init(user, tokenProvider, listener)
    }

    override fun sendMessage(channelType: String, channelId: String, message: Message): Call<Message> {
        // -> If no persistence handler was set, nothing is saved in the db.
        storageClient?.storeLastMessage(channelType, channelId, message) 
        return api.sendMessage(channelType, channelId, message)
    }

    //If client would like to use storage, all the logic lives inside the StorageClient.
    override fun getStorageClient(): StorageClient = storageClient ?: throw IllegalStateException(NO_STORAGE_MESSAGE)
}
```

Every module can provide its own factory with a specific configuration of `NewChatClientImpl`, so a default configuration is created accordingly with the module the costumer is using.

Inside `stream-chat-android-client` there's the proper factory: 

```
class SimpleChatFactory {
    fun create() = 
        NewChatClientImpl(api = ChatApi(), userInitiallizer = UserInitializer(), storageClient = null)
}
```

*No storage client is passed to `NewChatClientImpl` so it doesn't handle persistence.* 
**There's no implementation of StorageClient inside `stream-chat-android-client` because this module doesn't handle persistence, it only defines the contract that other libraries should follow.**

The other versions of chat can be kept so we don't break the code for old versions and clients using the other clients can keep using then. But all the other clients should do is to implement the `NewChatClient` and act just a way to configure the `NewChatClientImpl` and delegate the requests to it. Like the simplified example:

```
class NewChatDomain(private val chatClient: NewChatClient) : NewChatClient by chatClient

class NewChatDomainFactory {

    /*
     * NewChatDomain always comes with the RoomStorageClient. This factory creates a configuration of NewChatClient
     * that can delegate requests to storage.
     */
    fun create() = NewChatDomain(NewChatClientImpl(ChatApi(), UserInitializer(), RoomStorageClient()))
}
```

Under the hood `NewChatClient` is the only chat client that is being used. This way all a lot of code can be taken out of `ChatDomainImpl` and `ChatImpl`, also a client can use any chat client without worries of state consistency between the singletons (if state is needed). 

## Evaluation
The are pros and cons for this solution:

**pros** 

- Only onde chat client handling everything, which makes code easier to maintain.
- Less code duplication
- `NewChatClient` can be used across all libraries.

**cons**  

- As the `NewChatClient` defines contract for the other libraries it ends up being aware of more functionality than the current solution (it will be aware of markdown, persistence...). This topic can also be seen as a pro, as solution enforces domain driven design. 