### PR TITLE
[CAS-266] Fix HealthMonitor

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 - Add `Channel::cooldown` property to know how configured `cooldown` time for the channel
 - Fix FirebaseMessageParserImpl.verifyPayload() logic
 - Fix notification display condition
+- Fix Socket connection issues
 
 # 1.16.1 - Wed 25 Sep 2020
 - Remove `User` field on `ChannelUpdatedEvent`

--- a/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocket.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocket.kt
@@ -4,7 +4,6 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.observable.ChatObservable
 
 internal interface ChatSocket {
-    val state: ChatSocketService.State
     fun connect(user: User)
     fun connectAnonymously()
     @Deprecated(

--- a/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocket.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocket.kt
@@ -3,7 +3,7 @@ package io.getstream.chat.android.client.socket
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.observable.ChatObservable
 
-interface ChatSocket {
+internal interface ChatSocket {
     val state: ChatSocketService.State
     fun connect(user: User)
     fun connectAnonymously()

--- a/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketImpl.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketImpl.kt
@@ -21,9 +21,6 @@ internal class ChatSocketImpl(
         SocketFactory(eventsParser, parser, tokenManager)
     )
 
-    override val state: ChatSocketService.State
-        get() = service.state
-
     override fun connectAnonymously() {
         service.connect(wssUrl, apiKey, null)
     }

--- a/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketImpl.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketImpl.kt
@@ -14,11 +14,10 @@ internal class ChatSocketImpl(
 ) : ChatSocket {
 
     private val eventsParser = EventsParser(parser)
-
-    private val service = ChatSocketServiceImpl(
-        eventsParser,
+    private val service = ChatSocketServiceImpl.create(
         tokenManager,
-        SocketFactory(eventsParser, parser, tokenManager)
+        SocketFactory(eventsParser, parser, tokenManager),
+        eventsParser
     )
 
     override fun connectAnonymously() {

--- a/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketService.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketService.kt
@@ -17,11 +17,4 @@ internal interface ChatSocketService {
     fun onSocketError(error: ChatError)
     fun onConnectionResolved(event: ConnectedEvent)
     fun onEvent(event: ChatEvent)
-
-    sealed class State {
-        object Connecting : State()
-        data class Connected(val event: ConnectedEvent) : State()
-        data class Disconnected(val connectionWillFollow: Boolean) : State()
-        data class Error(val error: ChatError) : State()
-    }
 }

--- a/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketService.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketService.kt
@@ -7,8 +7,6 @@ import io.getstream.chat.android.client.models.User
 
 internal interface ChatSocketService {
 
-    var state: State
-
     fun connect(endpoint: String, apiKey: String, user: User?)
 
     fun disconnect()

--- a/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketService.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketService.kt
@@ -22,8 +22,8 @@ internal interface ChatSocketService {
 
     sealed class State {
         object Connecting : State()
-        class Connected(val event: ConnectedEvent) : State()
-        class Disconnected(val connectionWillFollow: Boolean) : State()
-        class Error(val error: ChatError) : State()
+        data class Connected(val event: ConnectedEvent) : State()
+        data class Disconnected(val connectionWillFollow: Boolean) : State()
+        data class Error(val error: ChatError) : State()
     }
 }

--- a/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketService.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketService.kt
@@ -6,7 +6,7 @@ import io.getstream.chat.android.client.events.ConnectedEvent
 import io.getstream.chat.android.client.models.User
 import java.util.Date
 
-interface ChatSocketService {
+internal interface ChatSocketService {
 
     var state: State
 

--- a/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketService.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketService.kt
@@ -4,7 +4,6 @@ import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.events.ConnectedEvent
 import io.getstream.chat.android.client.models.User
-import java.util.Date
 
 internal interface ChatSocketService {
 
@@ -20,7 +19,6 @@ internal interface ChatSocketService {
     fun onSocketError(error: ChatError)
     fun onConnectionResolved(event: ConnectedEvent)
     fun onEvent(event: ChatEvent)
-    fun setLastEventDate(date: Date)
 
     sealed class State {
         object Connecting : State()

--- a/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketServiceImpl.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketServiceImpl.kt
@@ -25,7 +25,7 @@ internal class ChatSocketServiceImpl private constructor(
     private val eventUiHandler = Handler(Looper.getMainLooper())
     private val healthMonitor = HealthMonitor(
         object : HealthMonitor.HealthCallback {
-            override fun reconnect() = setupSocket()
+            override fun reconnect() = this@ChatSocketServiceImpl.reconnect()
             override fun check() {
                 (state as? State.Connected)?.let {
                     sendEvent(it.event)
@@ -121,6 +121,11 @@ internal class ChatSocketServiceImpl private constructor(
 
     internal fun sendEvent(event: ChatEvent) {
         socket?.send(event)
+    }
+
+    private fun reconnect() {
+        releaseSocket()
+        setupSocket()
     }
 
     private fun setupSocket() {

--- a/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketServiceImpl.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketServiceImpl.kt
@@ -9,7 +9,6 @@ import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.events.ConnectedEvent
 import io.getstream.chat.android.client.logger.ChatLogger
 import io.getstream.chat.android.client.models.User
-import io.getstream.chat.android.client.socket.ChatSocketService.State
 import io.getstream.chat.android.client.token.TokenManager
 import kotlin.properties.Delegates
 
@@ -146,5 +145,12 @@ internal class ChatSocketServiceImpl(
                 eventUiHandler.post { call(listener) }
             }
         }
+    }
+
+    private sealed class State {
+        object Connecting : State()
+        data class Connected(val event: ConnectedEvent) : State()
+        data class Disconnected(val connectionWillFollow: Boolean) : State()
+        data class Error(val error: ChatError) : State()
     }
 }

--- a/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketServiceImpl.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketServiceImpl.kt
@@ -12,8 +12,7 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.token.TokenManager
 import kotlin.properties.Delegates
 
-internal class ChatSocketServiceImpl(
-    eventsParser: EventsParser,
+internal class ChatSocketServiceImpl private constructor(
     private val tokenManager: TokenManager,
     private val socketFactory: SocketFactory
 ) : ChatSocketService {
@@ -64,10 +63,6 @@ internal class ChatSocketServiceImpl(
             }
         }
     )
-
-    init {
-        eventsParser.setSocketService(this)
-    }
 
     override fun onSocketError(error: ChatError) {
         logger.logE(error)
@@ -152,5 +147,13 @@ internal class ChatSocketServiceImpl(
         data class Connected(val event: ConnectedEvent) : State()
         data class Disconnected(val connectionWillFollow: Boolean) : State()
         data class Error(val error: ChatError) : State()
+    }
+
+    companion object {
+        fun create(
+            tokenManager: TokenManager,
+            socketFactory: SocketFactory,
+            eventsParser: EventsParser
+        ): ChatSocketServiceImpl = ChatSocketServiceImpl(tokenManager, socketFactory).also { eventsParser.setSocketService(it) }
     }
 }

--- a/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketServiceImpl.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketServiceImpl.kt
@@ -11,7 +11,6 @@ import io.getstream.chat.android.client.logger.ChatLogger
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.socket.ChatSocketService.State
 import io.getstream.chat.android.client.token.TokenManager
-import java.util.Date
 
 internal class ChatSocketServiceImpl(
     eventsParser: EventsParser,
@@ -34,10 +33,6 @@ internal class ChatSocketServiceImpl(
 
     init {
         eventsParser.setSocketService(this)
-    }
-
-    override fun setLastEventDate(date: Date) {
-        healthMonitor.lastEventDate = date
     }
 
     override fun onSocketError(error: ChatError) {

--- a/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketServiceImpl.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketServiceImpl.kt
@@ -130,7 +130,7 @@ internal class ChatSocketServiceImpl private constructor(
     }
 
     private fun releaseSocket() {
-        socket?.close(1000, "bye")
+        socket?.close(1000, "Connection close by client")
         socket = null
     }
 

--- a/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketServiceImpl.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/ChatSocketServiceImpl.kt
@@ -36,7 +36,7 @@ internal class ChatSocketServiceImpl(
         }
     )
 
-    override var state: State by Delegates.observable(
+    private var state: State by Delegates.observable(
         State.Disconnected(true) as State,
         { _, oldState, newState ->
             if (oldState != newState) {

--- a/client/src/main/java/io/getstream/chat/android/client/socket/HealthMonitor.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/socket/HealthMonitor.kt
@@ -8,72 +8,61 @@ import kotlin.math.floor
 import kotlin.math.max
 import kotlin.math.min
 
-internal class HealthMonitor(val socket: ChatSocketServiceImpl) {
+private const val HEALTH_CHECK_INTERVAL = 10 * 1000L
+private const val MONITOR_INTERVAL = 1000L
+private const val NO_EVENT_INTERVAL_THRESHOLD = HEALTH_CHECK_INTERVAL + 10 * MONITOR_INTERVAL
+internal class HealthMonitor(private val healthCallback: HealthCallback) {
 
     private val delayHandler = Handler(Looper.getMainLooper())
-    private val healthCheckInterval = 30 * 1000L
     private var consecutiveFailures = 0
-    var lastEventDate: Date? = null
+    private var lastEventDate: Date = Date()
 
     private val logger = ChatLogger.get("SocketMonitor")
 
     private val reconnect = Runnable {
-        socket.setupSocket()
+        healthCallback.reconnect()
     }
 
     private val healthCheck: Runnable = Runnable {
-        (socket.state as? ChatSocketService.State.Connected)?.let {
-            logger.logI("Ok")
-            consecutiveFailures = 0
-            socket.sendEvent(it.event)
-            delayHandler.postDelayed(monitor, healthCheckInterval)
-        }
+        logger.logI("Ok")
+        consecutiveFailures = 0
+        healthCallback.check()
+        delayHandler.postDelayed(monitor, HEALTH_CHECK_INTERVAL)
     }
 
     private val monitor = Runnable {
-        if (socket.state is ChatSocketService.State.Connected) {
-            val millisNow = Date().time
-            val monitorInterval = 1000L
-
-            lastEventDate?.let {
-                val diff = millisNow - it.time
-                val checkInterval = healthCheckInterval + 10 * 1000
-                if (diff > checkInterval) {
-                    consecutiveFailures += 1
-                    reconnect()
-                }
-            }
-
-            delayHandler.postDelayed(healthCheck, monitorInterval)
-        }
+        if (needToReconnect()) reconnect()
+        delayHandler.postDelayed(healthCheck, MONITOR_INTERVAL)
     }
 
     fun start() {
         logger.logI("Start")
+        lastEventDate = Date()
         monitor.run()
     }
 
-    fun reset() {
+    fun stop() {
         delayHandler.removeCallbacks(monitor)
         delayHandler.removeCallbacks(reconnect)
         delayHandler.removeCallbacks(healthCheck)
-        lastEventDate = null
+    }
+
+    fun ack() {
+        lastEventDate = Date()
     }
 
     fun onError() {
         logger.logI("Error")
-        consecutiveFailures++
         reconnect()
     }
 
     private fun reconnect() {
-        val retryInterval = getRetryInterval(consecutiveFailures)
+        val retryInterval = getRetryInterval(++consecutiveFailures)
         logger.logI("Next connection attempt in $retryInterval ms")
-        delayHandler.postDelayed(
-            reconnect,
-            retryInterval
-        )
+        delayHandler.postDelayed(reconnect, retryInterval)
     }
+
+    private fun needToReconnect() = (Date().time - lastEventDate.time) >= NO_EVENT_INTERVAL_THRESHOLD
 
     private fun getRetryInterval(consecutiveFailures: Int): Long {
         val max = min(500 + consecutiveFailures * 2000, 25000)
@@ -82,5 +71,10 @@ internal class HealthMonitor(val socket: ChatSocketServiceImpl) {
             25000
         )
         return floor(Math.random() * (max - min) + min).toLong()
+    }
+
+    interface HealthCallback {
+        fun check()
+        fun reconnect()
     }
 }

--- a/client/src/main/java/io/getstream/chat/android/client/utils/observable/ChatEventsObservable.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/utils/observable/ChatEventsObservable.kt
@@ -8,7 +8,6 @@ import io.getstream.chat.android.client.events.DisconnectedEvent
 import io.getstream.chat.android.client.events.ErrorEvent
 import io.getstream.chat.android.client.models.EventType
 import io.getstream.chat.android.client.socket.ChatSocket
-import io.getstream.chat.android.client.socket.ChatSocketService
 import io.getstream.chat.android.client.socket.SocketListener
 import java.util.Date
 
@@ -59,23 +58,7 @@ internal class ChatEventsObservable(private val socket: ChatSocket) {
 
         subscriptions.add(subscription)
 
-        deliverInitState(subscription)
-
         return subscription
-    }
-
-    private fun deliverInitState(subscription: EventSubscription) {
-        val firstEvent: ChatEvent = when (val state = socket.state) {
-            is ChatSocketService.State.Connected ->
-                state.event
-            is ChatSocketService.State.Connecting ->
-                ConnectingEvent(EventType.CONNECTION_CONNECTING, Date())
-            is ChatSocketService.State.Disconnected ->
-                DisconnectedEvent(EventType.CONNECTION_DISCONNECTED, Date())
-            else -> return
-        }
-
-        subscription.onNext(firstEvent)
     }
 
     /**

--- a/client/src/main/java/io/getstream/chat/android/client/utils/observable/ChatObservableImpl.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/utils/observable/ChatObservableImpl.kt
@@ -61,8 +61,6 @@ internal class ChatObservableImpl(private val service: ChatSocketService) : Chat
 
         subscriptions.add(result)
 
-        if (!ignoreInitState) deliverInitState(result)
-
         return result
     }
 
@@ -72,22 +70,6 @@ internal class ChatObservableImpl(private val service: ChatSocketService) : Chat
         if (subscriptions.isEmpty()) {
             service.removeListener(eventsMapper)
         }
-    }
-
-    private fun deliverInitState(subscription: Subscription) {
-
-        var firstEvent: ChatEvent? = null
-
-        when (val state = service.state) {
-            is ChatSocketService.State.Connected ->
-                firstEvent = state.event
-            is ChatSocketService.State.Connecting ->
-                firstEvent = ConnectingEvent(EventType.CONNECTION_CONNECTING, Date())
-            is ChatSocketService.State.Disconnected ->
-                firstEvent = DisconnectedEvent(EventType.CONNECTION_DISCONNECTED, Date())
-        }
-
-        if (firstEvent != null) subscription.onNext(firstEvent)
     }
 
     /**

--- a/client/src/test/java/io/getstream/chat/android/client/MockClientBuilder.kt
+++ b/client/src/test/java/io/getstream/chat/android/client/MockClientBuilder.kt
@@ -40,7 +40,7 @@ class MockClientBuilder {
         connectionId
     )
 
-    lateinit var socket: FakeChatSocket
+    private lateinit var socket: FakeChatSocket
     lateinit var retrofitCdnApi: RetrofitCdnApi
 
     internal lateinit var retrofitApi: RetrofitApi

--- a/client/src/test/java/io/getstream/chat/android/client/parser/EventsParserTests.kt
+++ b/client/src/test/java/io/getstream/chat/android/client/parser/EventsParserTests.kt
@@ -15,13 +15,12 @@ import org.mockito.Mockito
 
 class EventsParserTests {
 
-    val socket = Mockito.mock(WebSocket::class.java)
-    lateinit var eventsCollector: MutableList<ChatEvent>
-    lateinit var service: FakeSocketService
+    private val socket = Mockito.mock(WebSocket::class.java)
+    private lateinit var eventsCollector: MutableList<ChatEvent>
+    private lateinit var service: FakeSocketService
     private lateinit var parser: EventsParser
-
-    val userId = "hello-user"
-    val eventType = EventType.HEALTH_CHECK
+    private val userId = "hello-user"
+    private val eventType = EventType.HEALTH_CHECK
 
     @Before
     fun before() {

--- a/client/src/test/java/io/getstream/chat/android/client/utils/observable/FakeChatSocket.kt
+++ b/client/src/test/java/io/getstream/chat/android/client/utils/observable/FakeChatSocket.kt
@@ -1,16 +1,11 @@
 package io.getstream.chat.android.client.utils.observable
 
-import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.socket.ChatSocket
-import io.getstream.chat.android.client.socket.ChatSocketService
 import io.getstream.chat.android.client.socket.SocketListener
 
 internal class FakeChatSocket : ChatSocket {
-
-    override val state: ChatSocketService.State
-        get() = ChatSocketService.State.Error(ChatError(""))
 
     private val listeners = mutableSetOf<SocketListener>()
 

--- a/client/src/test/java/io/getstream/chat/android/client/utils/observable/FakeChatSocket.kt
+++ b/client/src/test/java/io/getstream/chat/android/client/utils/observable/FakeChatSocket.kt
@@ -7,7 +7,7 @@ import io.getstream.chat.android.client.socket.ChatSocket
 import io.getstream.chat.android.client.socket.ChatSocketService
 import io.getstream.chat.android.client.socket.SocketListener
 
-class FakeChatSocket : ChatSocket {
+internal class FakeChatSocket : ChatSocket {
 
     override val state: ChatSocketService.State
         get() = ChatSocketService.State.Error(ChatError(""))

--- a/client/src/test/java/io/getstream/chat/android/client/utils/observable/FakeSocketService.kt
+++ b/client/src/test/java/io/getstream/chat/android/client/utils/observable/FakeSocketService.kt
@@ -14,8 +14,6 @@ internal class FakeSocketService(
 
     private var connectionUserId: String? = null
 
-    override var state: ChatSocketService.State = ChatSocketService.State.Disconnected(false)
-
     override fun connect(endpoint: String, apiKey: String, user: User?) {
     }
 

--- a/client/src/test/java/io/getstream/chat/android/client/utils/observable/FakeSocketService.kt
+++ b/client/src/test/java/io/getstream/chat/android/client/utils/observable/FakeSocketService.kt
@@ -7,7 +7,6 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.socket.ChatSocketService
 import io.getstream.chat.android.client.socket.SocketListener
 import org.assertj.core.api.Assertions.assertThat
-import java.util.Date
 
 internal class FakeSocketService(
     val eventsCollector: MutableList<ChatEvent> = mutableListOf()
@@ -48,9 +47,6 @@ internal class FakeSocketService(
 
     override fun onEvent(event: ChatEvent) {
         eventsCollector.add(event)
-    }
-
-    override fun setLastEventDate(date: Date) {
     }
 
     fun verifyConnectionUserId(userId: String) {

--- a/client/src/test/java/io/getstream/chat/android/client/utils/observable/FakeSocketService.kt
+++ b/client/src/test/java/io/getstream/chat/android/client/utils/observable/FakeSocketService.kt
@@ -9,7 +9,7 @@ import io.getstream.chat.android.client.socket.SocketListener
 import org.assertj.core.api.Assertions.assertThat
 import java.util.Date
 
-class FakeSocketService(
+internal class FakeSocketService(
     val eventsCollector: MutableList<ChatEvent> = mutableListOf()
 ) : ChatSocketService {
 


### PR DESCRIPTION
We have a class called `HealthMonitor` that, periodically checks our socket connection and tries to reconnect our client if it was closed, but it is not working fine.
It works together with `ChatSocketServiceImpl` to keep the socket connection open with our server.

Both classes have been refactored and connection/disconnection events are working fine now.