### PR TITLE
Use AttachmentHelper for validating only imageUrls

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 # To be released:
 
+- Use AttachmentsHelper to validate imageUrl instead of just url.
+
 # 1.16.6 - Fri 9th of Oct 2020
 - Add `createdLocallyAt` and `updatedLocallyAt` properties to `Message` type
 - Add AttachmentsHelper with hasValidUrl method

--- a/client/src/main/java/io/getstream/chat/android/client/helpers/AttachmentHelper.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/helpers/AttachmentHelper.kt
@@ -6,8 +6,8 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 
 class AttachmentHelper(private val systemTimeProvider: SystemTimeProvider = SystemTimeProvider()) {
 
-    fun hasValidUrl(attachment: Attachment): Boolean {
-        val url = attachment.url?.toHttpUrlOrNull() ?: return false
+    fun hasValidImageUrl(attachment: Attachment): Boolean {
+        val url = attachment.imageUrl?.toHttpUrlOrNull() ?: return false
         if (url.queryParameterNames.contains(QUERY_KEY_NAME_EXPIRES).not()) {
             return true
         }

--- a/client/src/main/java/io/getstream/chat/android/client/helpers/AttachmentHelper.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/helpers/AttachmentHelper.kt
@@ -12,7 +12,7 @@ class AttachmentHelper(private val systemTimeProvider: SystemTimeProvider = Syst
             return true
         }
         val timestamp = url.queryParameter(QUERY_KEY_NAME_EXPIRES)?.toLongOrNull() ?: return false
-        return timestamp > systemTimeProvider.provideTime()
+        return timestamp > systemTimeProvider.provideCurrentTimeInSeconds()
     }
 
     companion object {

--- a/client/src/main/java/io/getstream/chat/android/client/utils/SystemTimeProvider.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/utils/SystemTimeProvider.kt
@@ -1,7 +1,7 @@
 package io.getstream.chat.android.client.utils
 
 class SystemTimeProvider {
-    fun provideTime() = System.currentTimeMillis() / MILLIS_TO_SECONDS_FACTOR
+    fun provideCurrentTimeInSeconds() = System.currentTimeMillis() / MILLIS_TO_SECONDS_FACTOR
 
     companion object {
         private const val MILLIS_TO_SECONDS_FACTOR = 1000L

--- a/client/src/main/java/io/getstream/chat/android/client/utils/SystemTimeProvider.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/utils/SystemTimeProvider.kt
@@ -1,5 +1,9 @@
 package io.getstream.chat.android.client.utils
 
 class SystemTimeProvider {
-    fun provideTime() = System.currentTimeMillis()
+    fun provideTime() = System.currentTimeMillis() / MILLIS_TO_SECONDS_FACTOR
+
+    companion object {
+        private const val MILLIS_TO_SECONDS_FACTOR = 1000L
+    }
 }

--- a/client/src/test/java/io/getstream/chat/android/client/helpers/AttachmentHelperTests.kt
+++ b/client/src/test/java/io/getstream/chat/android/client/helpers/AttachmentHelperTests.kt
@@ -24,65 +24,65 @@ internal class AttachmentHelperTests {
     }
 
     @Test
-    fun `When has valid url If attachment has null url Should return false`() {
-        val attachment = Mother.randomAttachment { url = null }
+    fun `When has valid image url If attachment has null url Should return false`() {
+        val attachment = Mother.randomAttachment { imageUrl = null }
 
-        val result = sut.hasValidUrl(attachment)
+        val result = sut.hasValidImageUrl(attachment)
 
         result shouldBeEqualTo false
     }
 
     @ParameterizedTest
     @MethodSource("nonValidUrls")
-    fun `When has valid url if attachment url is not valid Should return false`(notValidUrl: String) {
-        val attachment = Mother.randomAttachment { url = notValidUrl }
+    fun `When has valid image url if attachment url is not valid Should return false`(notValidUrl: String) {
+        val attachment = Mother.randomAttachment { imageUrl = notValidUrl }
 
-        val result = sut.hasValidUrl(attachment)
+        val result = sut.hasValidImageUrl(attachment)
 
         result shouldBeEqualTo false
     }
 
     @Test
-    fun `When has valid url if attachment url is valid without Expires Should return true`() {
-        val attachment = Mother.randomAttachment { url = "https://www.someDomain.com/some-resource-id1.jpg" }
+    fun `When has valid image url if attachment url is valid without Expires Should return true`() {
+        val attachment = Mother.randomAttachment { imageUrl = "https://www.someDomain.com/some-resource-id1.jpg" }
 
-        val result = sut.hasValidUrl(attachment)
+        val result = sut.hasValidImageUrl(attachment)
 
         result shouldBeEqualTo true
     }
 
     @Test
-    fun `When has valid url if attachment url is valid with Expires and failed to parse timestamp Should return false`() {
+    fun `When has valid image url if attachment url is valid with Expires and failed to parse timestamp Should return false`() {
         val attachment =
-            Mother.randomAttachment { url = "https://www.someDomain.com/some-resource-id1.jpg?Expires=xxTTee" }
+            Mother.randomAttachment { imageUrl = "https://www.someDomain.com/some-resource-id1.jpg?Expires=xxTTee" }
 
-        val result = sut.hasValidUrl(attachment)
+        val result = sut.hasValidImageUrl(attachment)
 
         result shouldBeEqualTo false
     }
 
     @Test
-    fun `When has valid url if attachment url is valid with Expires and timestamp is greater than current time Should return true`() {
+    fun `When has valid image url if attachment url is valid with Expires and timestamp is greater than current time Should return true`() {
         val currentTime = 1000L
         val timeStamp = currentTime + 100L
         When calling timeProvider.provideTime() doReturn currentTime
         val attachment =
-            Mother.randomAttachment { url = "https://www.someDomain.com/some-resource-id1.jpg?Expires=$timeStamp" }
+            Mother.randomAttachment { imageUrl = "https://www.someDomain.com/some-resource-id1.jpg?Expires=$timeStamp" }
 
-        val result = sut.hasValidUrl(attachment)
+        val result = sut.hasValidImageUrl(attachment)
 
         result shouldBeEqualTo true
     }
 
     @Test
-    fun `When has valid url if attachment url is valid with Expires and timestamp is less than current time Should return false`() {
+    fun `When has valid image url if attachment url is valid with Expires and timestamp is less than current time Should return false`() {
         val currentTime = 1000L
         val timeStamp = currentTime - 100L
         When calling timeProvider.provideTime() doReturn currentTime
         val attachment =
-            Mother.randomAttachment { url = "https://www.someDomain.com/some-resource-id1.jpg?Expires=$timeStamp" }
+            Mother.randomAttachment { imageUrl = "https://www.someDomain.com/some-resource-id1.jpg?Expires=$timeStamp" }
 
-        val result = sut.hasValidUrl(attachment)
+        val result = sut.hasValidImageUrl(attachment)
 
         result shouldBeEqualTo false
     }

--- a/client/src/test/java/io/getstream/chat/android/client/helpers/AttachmentHelperTests.kt
+++ b/client/src/test/java/io/getstream/chat/android/client/helpers/AttachmentHelperTests.kt
@@ -65,7 +65,7 @@ internal class AttachmentHelperTests {
     fun `When has valid image url if attachment url is valid with Expires and timestamp is greater than current time Should return true`() {
         val currentTime = 1000L
         val timeStamp = currentTime + 100L
-        When calling timeProvider.provideTime() doReturn currentTime
+        When calling timeProvider.provideCurrentTimeInSeconds() doReturn currentTime
         val attachment =
             Mother.randomAttachment { imageUrl = "https://www.someDomain.com/some-resource-id1.jpg?Expires=$timeStamp" }
 
@@ -78,7 +78,7 @@ internal class AttachmentHelperTests {
     fun `When has valid image url if attachment url is valid with Expires and timestamp is less than current time Should return false`() {
         val currentTime = 1000L
         val timeStamp = currentTime - 100L
-        When calling timeProvider.provideTime() doReturn currentTime
+        When calling timeProvider.provideCurrentTimeInSeconds() doReturn currentTime
         val attachment =
             Mother.randomAttachment { imageUrl = "https://www.someDomain.com/some-resource-id1.jpg?Expires=$timeStamp" }
 


### PR DESCRIPTION
[CAS-286](https://stream-io.atlassian.net/secure/RapidBoard.jspa?rapidView=49&projectKey=CAS&modal=detail&selectedIssue=CAS-286)

### Description

Working close to backend team, I revealed that our url link is not changed. We use in ViewHolders imageUrls, and they are changing every time when we request them via backend. So we have to validate only imageUrls, we don't need to validate attachment_url or simple url since it doesn't impact our reloading issues.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
