### PR TITLE
Make ChatNotificationHandler.config public

### DIFF
--- a/client/src/main/java/io/getstream/chat/android/client/notifications/handler/ChatNotificationHandler.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/notifications/handler/ChatNotificationHandler.kt
@@ -30,7 +30,7 @@ import io.getstream.chat.android.client.receivers.NotificationMessageReceiver
 
 public open class ChatNotificationHandler @JvmOverloads constructor(
     protected val context: Context,
-    protected val config: NotificationConfig = NotificationConfig()
+    public val config: NotificationConfig = NotificationConfig()
 ) {
     private val logger = ChatLogger.get("ChatNotificationHandler")
 


### PR DESCRIPTION
### Description

Exposing `NotificationConfig` by `ChatNotificationHandler`. 
`NotificationConfig` needs to be serialized and stored locally in livedata. Now it's passed directly to`Chat.Builder` and an instance of `ChatNotificationHandler` is created internally. However, there is a need to allow user to provide their own `ChatNotificationHandler` implementation to customize notification's behaviour (e.g. pending intent, etc.). On that case it's needed to clean up `Chat.Builder` API by replacing passing `NotificationConfig` by `ChatNotificationHandler`.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
