### PR TITLE
Add last updated field to channel

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 # To be released:
+- Add `lastUpdated` property to `Channel`
 
 # 1.16.7 - Wed 14th of Oct 2020
 - Removed many internal implementation classes and methods from the SDK's public API

--- a/client/src/main/java/io/getstream/chat/android/client/models/Channel.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/models/Channel.kt
@@ -53,4 +53,8 @@ public data class Channel(
     @IgnoreDeserialisation
     var hiddenMessagesBefore: Date? = null,
     val cooldown: Int = 0
-) : CustomObject
+) : CustomObject {
+
+    val lastUpdated: Date?
+        get() = lastMessageAt?.takeIf { createdAt == null || it.after(createdAt) } ?: createdAt
+}


### PR DESCRIPTION
### Description

Add `lastUpdated` property to `Channel`.
It is a computed value by `max(last_message_at, created_at)`

### Checklist

- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
