### PR TITLE
Fix ConcurrentModificationException into our `ChatEventsObservable`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,6 @@
 # To be released:
+- Fix ConcurrentModificationException into our `ChatEventsObservable`
+
 # 1.16.8 - Fri 16th of Oct 2020
 - Add `lastUpdated` property to `Channel`
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 # To be released:
-- Fix ConcurrentModificationException into our `ChatEventsObservable`
+- Fix ConcurrentModificationException in `ChatEventsObservable`
 
 # 1.16.8 - Fri 16th of Oct 2020
 - Add `lastUpdated` property to `Channel`

--- a/client/src/main/java/io/getstream/chat/android/client/utils/observable/ChatEventsObservable.kt
+++ b/client/src/main/java/io/getstream/chat/android/client/utils/observable/ChatEventsObservable.kt
@@ -13,7 +13,7 @@ import java.util.Date
 
 internal class ChatEventsObservable(private val socket: ChatSocket) {
 
-    private val subscriptions = mutableSetOf<EventSubscription>()
+    private var subscriptions = setOf<EventSubscription>()
     private var eventsMapper = EventsMapper(this)
 
     private fun onNext(event: ChatEvent) {
@@ -22,7 +22,7 @@ internal class ChatEventsObservable(private val socket: ChatSocket) {
                 subscription.onNext(event)
             }
         }
-        subscriptions.removeAll(Disposable::isDisposed)
+        subscriptions = subscriptions.filterNot(Disposable::isDisposed).toSet()
         checkIfEmpty()
     }
 
@@ -56,7 +56,7 @@ internal class ChatEventsObservable(private val socket: ChatSocket) {
             socket.addListener(eventsMapper)
         }
 
-        subscriptions.add(subscription)
+        subscriptions = subscriptions + subscription
 
         return subscription
     }


### PR DESCRIPTION
### Description
Fix ConcurrentModificationException into our `ChatEventsObservable`

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
